### PR TITLE
Replacing cPickle to pickle

### DIFF
--- a/src/wgcca.py
+++ b/src/wgcca.py
@@ -400,7 +400,7 @@ def main(inPath, outPath, modelPath, k, keptViews=None, weights=None, regs=None,
       wgcca.G_scaled = None
     
     modelFile = fopen(modelPath, 'wb')
-    cPickle.dump(wgcca, modelFile)
+    pickle.dump(wgcca, modelFile)
     modelFile.close()
   
   # Save training set embeddings


### PR DESCRIPTION
Hi Adrian,

In the commit 820861eaa5c8f660134993424aee3d4978ecb962, you replaced cPickle to pickle but it seems that change is not reflected to the code globally.
One line change!

Best,
Yoshinari